### PR TITLE
Device level query

### DIFF
--- a/device level query
+++ b/device level query
@@ -180,7 +180,7 @@ WHERE
 	first_activity_date is NOT NULL
 GROUP BY
 	1,2,3,4
-	) select * from reengaged_users;
+	) -- select * from reengaged_users;
 		
     ,daily_revenue AS
 	(

--- a/device level query
+++ b/device level query
@@ -1,0 +1,254 @@
+WITH devices AS
+	(
+
+		SELECT
+			DISTINCT UPPER(device_id)    AS s
+				   ,   fact_game_device_install.game_name
+				   ,   fact_game_device_install.platform
+				   ,   'Remerge'   AS  campaign_channel
+				   ,   grp
+                   --,   Case WHEN max(LTV_IN_MICRO_CENTS)>0 then 'Spender' ELSE 'Non Spender' end as spender_group --CASE WHEN LTV_IN_MICRO_CENTS > 0 THEN 'Spender'
+                         --   ELSE 'Non Spender'
+                       --END AS spender_group
+				   ,   CASE -- KKH Remerge:  CID27703, CID27704, CID27594, CID27705, CID27706, CID27593 -- cf CID23719 CID23718
+					       WHEN    remerge_devices.campaign_name = 'Android_Q12021_Ongoing' AND remerge_devices.game_name =   'CovetFashion'
+						       THEN    'CF_Android_ALL_Both_Video_AEO_Feb2021_Lapsed_CID23719'
+					       WHEN    remerge_devices.campaign_name = 'iOS_Q12021_Ongoing' AND remerge_devices.game_name =   'CovetFashion'
+						       THEN    'CF_iOS_ALL_Both_Video_Feb2021_Lapsed_CID23718'
+			END     AS campaign_name -- update the campaign name to match to the other source tables - spend_data_raw and singular_clicks_orc
+
+		FROM
+			glu.adhoc.remerge_devices
+				INNER JOIN
+			glu.dwh_dev.fact_game_device_install
+			ON
+				(       UPPER(remerge_devices.device_id)    =   fact_game_device_install.s
+					AND    remerge_devices.game_name            =   fact_game_device_install.game
+					AND    UPPER(remerge_devices.platform)     =   fact_game_device_install.platform
+					)
+
+		WHERE 
+				remerge_devices.campaign_name IN ('Android_Q12021_Ongoing','iOS_Q12021_Ongoing') -- campaign name in remerge devices table -- shamanth gave the name of campaign
+		  AND remerge_devices.game_name =     'CovetFashion' --- game name
+		  AND date_sent_to_remerge BETWEEN    DATE('2021-07-01') AND  DATE('2021-08-31') -- campaign dates
+)  --select * from devices order by s;
+   
+, 
+    players_group AS
+   (
+
+SELECT
+	game_name
+		,   platform
+		,   campaign_channel
+		,   campaign_name
+		,   SUM(CASE
+	WHEN grp = 'TEST'
+	THEN 1
+	ELSE 0
+	END) AS number_of_players_in_test_grp
+		,   SUM(CASE
+	WHEN grp = 'CONTROL'
+	THEN 1
+	ELSE 0
+	END) AS number_of_players_in_control_grp
+FROM
+	devices
+
+GROUP BY
+	1,2,3,4
+
+	) --select * from players_group;
+	,snapshot_users
+	AS
+	(
+SELECT
+	devices.s
+		,   devices.campaign_name
+		,   devices.game_name
+		,   devices.platform
+		,   devices.campaign_channel
+		,   devices.grp
+        --,   devices.spender_group
+		,   MIN(first_session_date) first_session_date
+FROM
+	devices
+
+	LEFT OUTER JOIN
+	(SELECT
+	s
+		,   game_name
+		,   MIN(the_date) AS first_session_date
+	FROM
+	glu.adrift.game_device_daily_snapshot
+	WHERE
+	the_date BETWEEN DATE('2021-07-01') AND  DATEADD(DAY,6,DATE('2021-08-31'))
+	GROUP BY
+	1,2
+	) AS snapshot
+ON
+	devices.s           =   snapshot.s
+	AND devices.game_name   =   snapshot.game_name
+group by 1,2,3,4,5,6
+	)
+		,
+	device_clicks AS
+	(
+SELECT
+	s
+		,   campaign_name
+		,   game_name
+		,   platform
+		,   campaign_channel
+		,   grp
+        --,   spender_group
+		,   has_click
+	-- ,   LEAST(COALESCE(first_session_date ,first_click_date), COALESCE(first_click_date , first_session_date)) AS  first_activity_date  -- which is correct?
+		,   COALESCE(first_click_date , first_session_date) AS  first_activity_date
+		,   first_session_date
+		,   first_click_date
+FROM(
+	SELECT
+	snapshot_users.s
+		,   snapshot_users.campaign_name
+		,   snapshot_users.game_name
+		,   snapshot_users.platform
+		,   snapshot_users.campaign_channel
+		,   snapshot_users.grp
+        --,   snapshot_users.spender_group
+		,   CASE WHEN clicks.s IS NOT NULL THEN 1 ELSE 0 END AS has_click
+		,   MIN(first_session_date)     AS first_session_date
+		,   MIN(first_click_date)       AS  first_click_date
+	FROM
+	snapshot_users
+
+	LEFT OUTER JOIN
+
+	( SELECT
+	UPPER(device_id) AS s
+		,   campaign_name
+		,   MIN(DATE(timestamp))    AS  first_click_date
+
+	FROM
+	glu.adjust.singular_clicks_orc clicks
+
+
+	WHERE
+	clicks.campaign_name IN (
+	'CF_Android_ALL_Both_Video_AEO_Feb2021_Lapsed_CID23719'
+		,   'CF_iOS_ALL_Both_Video_Feb2021_Lapsed_CID23718') --- change campaign name -- Remerge:  CID27703, CID27704, CID27594, CID27705, CID27706, CID27593
+	AND DATE(timestamp) BETWEEN DATE('2021-07-01') AND  DATE('2021-08-31') -- change the dates here
+
+	GROUP BY
+	1,2
+	) AS clicks
+	ON
+	snapshot_users.s=clicks.s
+	AND
+	clicks.campaign_name=snapshot_users.campaign_name
+	GROUP BY 1,2,3,4,5,6,7
+	)) ,
+	reengaged_users AS
+	(   SELECT
+	game_name
+		,   platform
+		,   campaign_channel
+		,   campaign_name
+		,   SUM(CASE
+	WHEN grp = 'TEST'
+	THEN has_click
+	ELSE 0
+	END) AS number_of_test_users_with_clicks
+		,   SUM(CASE
+	WHEN grp = 'CONTROL'
+	THEN has_click
+	ELSE 0
+	END) AS number_of_control_users_with_clicks
+		,   SUM(CASE
+	WHEN grp = 'TEST'
+	THEN 1
+	ELSE 0
+	END) AS number_of_test_reengaged_users
+		,   SUM(CASE
+	WHEN grp = 'CONTROL'
+	THEN 1
+	ELSE 0
+	END) AS number_of_control_reengaged_users
+FROM
+	device_clicks
+WHERE
+	first_activity_date is NOT NULL
+GROUP BY
+	1,2,3,4
+	) select * from reengaged_users;
+		
+    ,daily_revenue AS
+	(
+SELECT
+	device_clicks.s
+		,   device_clicks.game_name
+		,   device_clicks.platform
+		--,   device_clicks.campaign_channel
+        ,   device_clicks.grp
+        --,   device_clicks.spender_group
+        --,   device_clicks.campaign_name
+        ,   the_date
+		,   SUM(net_revenue) net_revenue
+		
+FROM
+	device_clicks
+	LEFT OUTER JOIN
+	glu.adrift.game_device_daily_snapshot snapshot
+
+ON
+	device_clicks.s=snapshot.s
+	AND     device_clicks.game_name=snapshot.game_name
+    AND     the_date BETWEEN DATE('2021-07-01') AND  DATE('2021-08-31')
+	
+WHERE the_date is not NULL
+GROUP BY 1,2,3,4,5
+	) --select * from daily_revenue order by s, the_date;
+    
+     ,revenue_accu AS
+	(
+SELECT
+	device_clicks.s
+		,   device_clicks.game_name
+		,   device_clicks.platform
+		--,   device_clicks.campaign_channel
+        ,   device_clicks.grp
+        --,   device_clicks.spender_group
+        --,   device_clicks.campaign_name 
+		,   SUM(case when device_clicks.first_activity_date=snapshot.the_date then net_revenue else 0 end)                AS          d1_net_revenue
+		,   SUM(CASE
+	WHEN has_click=1 and device_clicks.first_activity_date=snapshot.the_date
+	THEN (net_revenue)
+	ELSE 0
+	END)                        AS      with_click_d1_net_revenue
+        ,   SUM(case when snapshot.the_date BETWEEN device_clicks.first_activity_date AND DATEADD(DAY,6,device_clicks.first_activity_date) then net_revenue else 0 end)                
+      AS          d7_net_revenue
+		,   SUM(CASE
+	WHEN has_click=1 and snapshot.the_date BETWEEN device_clicks.first_activity_date AND DATEADD(DAY,6,device_clicks.first_activity_date)
+	THEN (net_revenue)
+	ELSE 0
+	END)                        AS      with_click_d7_net_revenue
+      ,   SUM(case when snapshot.the_date BETWEEN device_clicks.first_activity_date AND DATEADD(DAY,29,device_clicks.first_activity_date) then net_revenue else 0 end)                
+      AS          d30_net_revenue
+		,   SUM(CASE
+	WHEN has_click=1 and (snapshot.the_date BETWEEN device_clicks.first_activity_date AND DATEADD(DAY,29,device_clicks.first_activity_date))
+	THEN (net_revenue)
+	ELSE 0
+	END)                        AS      with_click_d30_net_revenue
+		
+FROM
+	device_clicks
+	LEFT OUTER JOIN
+	glu.adrift.game_device_daily_snapshot snapshot
+
+ON
+	device_clicks.s=snapshot.s
+	AND     device_clicks.game_name=snapshot.game_name
+	
+
+GROUP BY 1,2,3,4
+	) 


### PR DESCRIPTION
I modified revenue subquery -
daily_revenue block is device level revenue by date;
revenue_accu block is device level accumulated D1/7/30 revenue;
You can write any "final" query to get your final metrics